### PR TITLE
Fix usage via generated bin

### DIFF
--- a/owners/__init__.py
+++ b/owners/__init__.py
@@ -1,4 +1,6 @@
 """CLI tool to inspect CODEOWNERS file.
 """
 
+from ._cli import entrypoint
+
 __version__ = '0.1.1'


### PR DESCRIPTION
When installed from source (`pip install .`), using the module as described in readme (`python3 -m owners -h`) works as expected. However, using via the generated bin results in an error:

```bash
$ owners -h
Traceback (most recent call last):
  File "/opt/homebrew/bin/owners", line 5, in <module>
    from owners import entrypoint
ImportError: cannot import name 'entrypoint' from 'owners' (/opt/homebrew/lib/python3.11/site-packages/owners/__init__.py)
```

Fix by importing the entrypoint in module init. Now both usages work:

<img width="866" alt="Screenshot 2024-02-02 at 14 04 01" src="https://github.com/orsinium-labs/owners/assets/25730717/87cad83d-46ae-429b-a8f1-bbd86f0e0cce">
